### PR TITLE
Update the docs to avoid case-sensitive OS problem

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -23,7 +23,7 @@ box install integrated
 Add the Integrated lib directory to `this.javaSettings` in your `*tests*` directory's `Application.cfc`.
 
 ```js
-this.javaSettings = { loadPaths = [ "Integrated/lib" ], reloadOnChange = false };
+this.javaSettings = { loadPaths = [ "integrated/lib" ], reloadOnChange = false };
 ```
 
 ### Usage


### PR DESCRIPTION
Integrated actually gets created with a lowercase i.
